### PR TITLE
Add support for Attachment & text messages

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -7,7 +7,7 @@ DEPENDENCIES:
   - MessageKit (from `../`)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  https://github.com/cocoapods/specs.git:
     - InputBarAccessoryView
 
 EXTERNAL SOURCES:
@@ -20,4 +20,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: cecdb7bc8129cf99f66de9f68eea3256fec30c3d
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.7.3

--- a/Example/Sources/Data Generation/SampleData.swift
+++ b/Example/Sources/Data Generation/SampleData.swift
@@ -202,7 +202,7 @@ final internal class SampleData {
             let randsomScale = CGFloat(Float(arc4random()) / Float(UINT32_MAX))
             let image = messageImages[randomNumberImage].scale(by: randsomScale)
             let randomSentence = Lorem.sentence(nbWords: 60) + " 123-456-7890\n" + "https://github.com/MessageKit"
-            return MockMessage(placeholderImage: image, imageURL: URL(string: "google.com")!, text: randomSentence, user: user, messageId: uniqueID, date: date)
+            return MockMessage(image: image, text: randomSentence, user: user, messageId: uniqueID, date: date)
         case .ShareContact:
             let randomContact = Int(arc4random_uniform(UInt32(contactsToShare.count)))
             return MockMessage(contact: contactsToShare[randomContact], user: user, messageId: uniqueID, date: date)

--- a/Example/Sources/Data Generation/SampleData.swift
+++ b/Example/Sources/Data Generation/SampleData.swift
@@ -43,6 +43,7 @@ final internal class SampleData {
         case Url
         case Phone
         case System
+        case Attachment
         case Custom
         case ShareContact
     }
@@ -153,7 +154,7 @@ final internal class SampleData {
         return messageTypes.random()!
     }
 
-    // swiftlint:disable cyclomatic_complexity
+    // swiftlint:disable cyclomatic_complexity function_body_length
     func randomMessage(allowedSenders: [MockUser]) -> MockMessage {
         let randomNumberSender = Int(arc4random_uniform(UInt32(allowedSenders.count)))
         
@@ -196,6 +197,12 @@ final internal class SampleData {
             return MockMessage(system: message, user: system, messageId: uniqueID, date: date)
         case .Custom:
             return MockMessage(custom: "Someone left the conversation", user: system, messageId: uniqueID, date: date)
+        case .Attachment:
+            let randomNumberImage = Int(arc4random_uniform(UInt32(messageImages.count)))
+            let randsomScale = CGFloat(Float(arc4random()) / Float(UINT32_MAX))
+            let image = messageImages[randomNumberImage].scale(by: randsomScale)
+            let randomSentence = Lorem.sentence(nbWords: 60) + " 123-456-7890\n" + "https://github.com/MessageKit"
+            return MockMessage(placeholderImage: image, imageURL: URL(string: "google.com")!, text: randomSentence, user: user, messageId: uniqueID, date: date)
         case .ShareContact:
             let randomContact = Int(arc4random_uniform(UInt32(contactsToShare.count)))
             return MockMessage(contact: contactsToShare[randomContact], user: user, messageId: uniqueID, date: date)

--- a/Example/Sources/Models/MockMessage.swift
+++ b/Example/Sources/Models/MockMessage.swift
@@ -52,6 +52,11 @@ private struct ImageMediaItem: MediaItem {
         self.placeholderImage = UIImage()
     }
 
+    init(url: URL, placeholderImage: UIImage) {
+        self.url = url
+        self.size = CGSize(width: 240, height: 240)
+        self.placeholderImage = placeholderImage
+    }
 }
 
 private struct MockAudiotem: AudioItem {
@@ -125,6 +130,11 @@ internal struct MockMessage: MessageType {
         self.init(kind: .photo(mediaItem), user: user, messageId: messageId, date: date)
     }
 
+    init(placeholderImage: UIImage, imageURL: URL, user: MockUser, messageId: String, date: Date) {
+        let mediaItem = ImageMediaItem(url: imageURL, placeholderImage: placeholderImage)
+        self.init(kind: .photo(mediaItem), user: user, messageId: messageId, date: date)
+    }
+
     init(thumbnail: UIImage, user: MockUser, messageId: String, date: Date) {
         let mediaItem = ImageMediaItem(image: thumbnail)
         self.init(kind: .video(mediaItem), user: user, messageId: messageId, date: date)
@@ -146,5 +156,10 @@ internal struct MockMessage: MessageType {
 
     init(contact: MockContactItem, user: MockUser, messageId: String, date: Date) {
         self.init(kind: .contact(contact), user: user, messageId: messageId, date: date)
+    }
+
+    init(placeholderImage: UIImage, imageURL: URL, text: String, user: MockUser, messageId: String, date: Date) {
+        let mediaItem = ImageMediaItem(url: imageURL, placeholderImage: placeholderImage)
+        self.init(kind: .attachment(text, mediaItem), user: user, messageId: messageId, date: date)
     }
 }

--- a/Example/Sources/Models/MockMessage.swift
+++ b/Example/Sources/Models/MockMessage.swift
@@ -162,4 +162,9 @@ internal struct MockMessage: MessageType {
         let mediaItem = ImageMediaItem(url: imageURL, placeholderImage: placeholderImage)
         self.init(kind: .attachment(text, mediaItem), user: user, messageId: messageId, date: date)
     }
+
+    init(image: UIImage, text: String, user: MockUser, messageId: String, date: Date) {
+        let mediaItem = ImageMediaItem(image: image)
+        self.init(kind: .attachment(text, mediaItem), user: user, messageId: messageId, date: date)
+    }
 }

--- a/Example/Sources/View Controllers/AdvancedExampleViewController.swift
+++ b/Example/Sources/View Controllers/AdvancedExampleViewController.swift
@@ -35,6 +35,11 @@ final class AdvancedExampleViewController: ChatViewController {
         messagesCollectionView = MessagesCollectionView(frame: .zero, collectionViewLayout: CustomMessagesFlowLayout())
         messagesCollectionView.register(CustomCell.self)
         super.viewDidLoad()
+        if #available(iOS 13.0, *) {
+            self.messagesCollectionView.backgroundColor = .systemBackground
+        } else {
+            self.messagesCollectionView.backgroundColor = .white
+        }
         
         updateTitleView(title: "MessageKit", subtitle: "2 Online")
     }
@@ -45,10 +50,10 @@ final class AdvancedExampleViewController: ChatViewController {
         MockSocket.shared.connect(with: [SampleData.shared.nathan, SampleData.shared.wu])
             .onTypingStatus { [weak self] in
                 self?.setTypingIndicatorViewHidden(false)
-            }.onNewMessage { [weak self] message in
-                self?.setTypingIndicatorViewHidden(true, performUpdates: {
-                    self?.insertMessage(message)
-                })
+        }.onNewMessage { [weak self] message in
+            self?.setTypingIndicatorViewHidden(true, performUpdates: {
+                self?.insertMessage(message)
+            })
         }
     }
     

--- a/Example/Sources/View Controllers/ChatViewController.swift
+++ b/Example/Sources/View Controllers/ChatViewController.swift
@@ -252,6 +252,10 @@ extension ChatViewController: MessageCellDelegate {
         print("Accessory view tapped")
     }
 
+    func didTapAttachment(in cell: AttachmentMessageCell) {
+        print("ImageView of Attachment tapped")
+    }
+
 }
 
 // MARK: - MessageLabelDelegate

--- a/Example/Sources/View Controllers/SettingsViewController.swift
+++ b/Example/Sources/View Controllers/SettingsViewController.swift
@@ -33,7 +33,7 @@ final internal class SettingsViewController: UITableViewController {
         return .lightContent
     }
     
-    let cells = ["Mock messages count", "Text Messages", "AttributedText Messages", "Photo Messages", "Video Messages", "Audio Messages", "Emoji Messages", "Location Messages", "Url Messages", "Phone Messages", "ShareContact Messages", "System Messages"]
+    let cells = ["Mock messages count", "Text Messages", "AttributedText Messages", "Photo Messages", "Video Messages", "Audio Messages", "Emoji Messages", "Location Messages", "Url Messages", "Phone Messages", "ShareContact Messages", "System Messages", "Attachment Messages"]
     
     // MARK: - Picker
     
@@ -89,7 +89,7 @@ final internal class SettingsViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cellValue = cells[indexPath.row]
         let cell = tableView.dequeueReusableCell(withIdentifier: "cell") ?? UITableViewCell()
-        cell.textLabel?.text = cells[indexPath.row]
+        cell.textLabel?.text = cellValue
         
         switch cellValue {
         case "Mock messages count":

--- a/MessageKit.xcodeproj/project.pbxproj
+++ b/MessageKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -38,7 +38,6 @@
 		383B9EB121728BAD008AB91A /* SenderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 383B9EB021728BAD008AB91A /* SenderType.swift */; };
 		388119462253EC30004B26AF /* TypingIndicatorCellSizeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388119452253EC30004B26AF /* TypingIndicatorCellSizeCalculator.swift */; };
 		38A2230F221FB8A300D14DAF /* MessageInputBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A2230E221FB8A300D14DAF /* MessageInputBar.swift */; };
-		38A223112223493500D14DAF /* InputBarAccessoryView.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 38A223102223493400D14DAF /* InputBarAccessoryView.framework */; };
 		38F8062F2173CD8F00CDB9DB /* MockUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F8062D2173CD4300CDB9DB /* MockUser.swift */; };
 		38F8063221740D9E00CDB9DB /* TypingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F8063021740D9D00CDB9DB /* TypingIndicator.swift */; };
 		38F8063321740D9E00CDB9DB /* BubbleCircle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F8063121740D9D00CDB9DB /* BubbleCircle.swift */; };
@@ -99,6 +98,7 @@
 		CD42644123CE4D7500294169 /* AttachmentMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD42644023CE4D7500294169 /* AttachmentMessageCell.swift */; };
 		CD8D8F9923AA35D5008EA777 /* SystemMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8D8F9823AA35D5008EA777 /* SystemMessageCell.swift */; };
 		CD8D8F9B23AA3B74008EA777 /* SystemMessageSizeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8D8F9A23AA3B74008EA777 /* SystemMessageSizeCalculator.swift */; };
+		CDCA9164258D62CE00B4622A /* InputBarAccessoryView.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDCA9163258D62CE00B4622A /* InputBarAccessoryView.xcframework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -221,6 +221,7 @@
 		CD42644023CE4D7500294169 /* AttachmentMessageCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttachmentMessageCell.swift; sourceTree = "<group>"; };
 		CD8D8F9823AA35D5008EA777 /* SystemMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMessageCell.swift; sourceTree = "<group>"; };
 		CD8D8F9A23AA3B74008EA777 /* SystemMessageSizeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMessageSizeCalculator.swift; sourceTree = "<group>"; };
+		CDCA9163258D62CE00B4622A /* InputBarAccessoryView.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = InputBarAccessoryView.xcframework; path = Carthage/Build/InputBarAccessoryView.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -228,7 +229,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				38A223112223493500D14DAF /* InputBarAccessoryView.framework in Frameworks */,
+				CDCA9164258D62CE00B4622A /* InputBarAccessoryView.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -248,6 +249,7 @@
 		1F7FC8C21FD26F22006CC979 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				CDCA9163258D62CE00B4622A /* InputBarAccessoryView.xcframework */,
 				38A223102223493400D14DAF /* InputBarAccessoryView.framework */,
 				38C2AE7B20D4878D00F8079E /* MessageInputBar.framework */,
 				1F7FC8C71FD26F49006CC979 /* Nimble.framework */,
@@ -882,7 +884,12 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Supporting/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(FRAMEWORK_SEARCH_PATHS)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+					"$(FRAMEWORK_SEARCH_PATHS)",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.messagekit.MessageKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -908,11 +915,17 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Supporting/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(FRAMEWORK_SEARCH_PATHS)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+					"$(FRAMEWORK_SEARCH_PATHS)",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.messagekit.MessageKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -925,7 +938,12 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = "Tests/Supporting Files/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(FRAMEWORK_SEARCH_PATHS)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+					"$(FRAMEWORK_SEARCH_PATHS)",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.hexedbits.MessageKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -939,10 +957,16 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = "Tests/Supporting Files/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(FRAMEWORK_SEARCH_PATHS)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+					"$(FRAMEWORK_SEARCH_PATHS)",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.hexedbits.MessageKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
 			name = Release;
 		};

--- a/MessageKit.xcodeproj/project.pbxproj
+++ b/MessageKit.xcodeproj/project.pbxproj
@@ -95,6 +95,8 @@
 		B7A03F731F866A06006AEF79 /* MessageKit+Availability.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7A03F701F866A06006AEF79 /* MessageKit+Availability.swift */; };
 		B7A03F751F866A06006AEF79 /* MessageKit.h in Headers */ = {isa = PBXBuildFile; fileRef = B7A03F721F866A06006AEF79 /* MessageKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B7A03F7B1F866B85006AEF79 /* MessageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7A03F7A1F866B85006AEF79 /* MessageCollectionViewCell.swift */; };
+		CD42643F23CE4D5B00294169 /* AttachmentMessageSizeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD42643E23CE4D5B00294169 /* AttachmentMessageSizeCalculator.swift */; };
+		CD42644123CE4D7500294169 /* AttachmentMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD42644023CE4D7500294169 /* AttachmentMessageCell.swift */; };
 		CD8D8F9923AA35D5008EA777 /* SystemMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8D8F9823AA35D5008EA777 /* SystemMessageCell.swift */; };
 		CD8D8F9B23AA3B74008EA777 /* SystemMessageSizeCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8D8F9A23AA3B74008EA777 /* SystemMessageSizeCalculator.swift */; };
 /* End PBXBuildFile section */
@@ -215,6 +217,8 @@
 		B7A03F711F866A06006AEF79 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B7A03F721F866A06006AEF79 /* MessageKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageKit.h; sourceTree = "<group>"; };
 		B7A03F7A1F866B85006AEF79 /* MessageCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageCollectionViewCell.swift; sourceTree = "<group>"; };
+		CD42643E23CE4D5B00294169 /* AttachmentMessageSizeCalculator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttachmentMessageSizeCalculator.swift; sourceTree = "<group>"; };
+		CD42644023CE4D7500294169 /* AttachmentMessageCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttachmentMessageCell.swift; sourceTree = "<group>"; };
 		CD8D8F9823AA35D5008EA777 /* SystemMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMessageCell.swift; sourceTree = "<group>"; };
 		CD8D8F9A23AA3B74008EA777 /* SystemMessageSizeCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMessageSizeCalculator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -256,6 +260,7 @@
 		2EB618F01F84676A007FBA0E /* Cells */ = {
 			isa = PBXGroup;
 			children = (
+				CD42644023CE4D7500294169 /* AttachmentMessageCell.swift */,
 				5073C1182175BE950040EAD5 /* AudioMessageCell.swift */,
 				50FF34582237FE840004DCD7 /* ContactMessageCell.swift */,
 				B7A03F381F866946006AEF79 /* LocationMessageCell.swift */,
@@ -484,6 +489,7 @@
 		B096439D1F295DC3004D0129 /* Layout */ = {
 			isa = PBXGroup;
 			children = (
+				CD42643E23CE4D5B00294169 /* AttachmentMessageSizeCalculator.swift */,
 				5073C11C2175BEC60040EAD5 /* AudioMessageSizeCalculator.swift */,
 				0EF0888B206F7E83007F2F58 /* CellSizeCalculator.swift */,
 				50FF345A2237FE9C0004DCD7 /* ContactMessageSizeCalculator.swift */,
@@ -646,6 +652,7 @@
 				B7A03F5B1F8669CA006AEF79 /* MessageType.swift in Sources */,
 				B7A03F601F8669CA006AEF79 /* MessagesDisplayDelegate.swift in Sources */,
 				1FE783A8206633C0007FA024 /* InsetLabel.swift in Sources */,
+				CD42643F23CE4D5B00294169 /* AttachmentMessageSizeCalculator.swift in Sources */,
 				38F8063321740D9E00CDB9DB /* BubbleCircle.swift in Sources */,
 				B7A03F5C1F8669CA006AEF79 /* MessageCellDelegate.swift in Sources */,
 				5073C11D2175BEC60040EAD5 /* AudioMessageSizeCalculator.swift in Sources */,
@@ -703,6 +710,7 @@
 				1F6C040C206A2891007BDE44 /* MessageContentCell.swift in Sources */,
 				B7A03F2C1F866895006AEF79 /* DetectorType.swift in Sources */,
 				B7A03F271F866895006AEF79 /* Avatar.swift in Sources */,
+				CD42644123CE4D7500294169 /* AttachmentMessageCell.swift in Sources */,
 				50FF34572237FE6A0004DCD7 /* UIImage+Extension.swift in Sources */,
 				1F82D1431FB1B75B00B81A88 /* AvatarPosition.swift in Sources */,
 				1FF377AC20087DA2004FD648 /* MessagesViewController+Keyboard.swift in Sources */,

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -382,6 +382,7 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
             selectedIndexPathForMenu = indexPath
             return true
         case .attachment(let text, _):
+            selectedIndexPathForMenu = indexPath
             return !text.isEmpty
         default:
             return false

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -24,6 +24,8 @@
 
 import UIKit
 import InputBarAccessoryView
+import MobileCoreServices
+
 
 /// A subclass of `UIViewController` with a `MessagesCollectionView` object
 /// that is used to display conversation interfaces.
@@ -379,6 +381,8 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
         case .text, .attributedText, .emoji, .photo:
             selectedIndexPathForMenu = indexPath
             return true
+        case .attachment(let text, _):
+            return !text.isEmpty
         default:
             return false
         }
@@ -405,6 +409,16 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
             pasteBoard.string = attributedText.string
         case .photo(let mediaItem):
             pasteBoard.image = mediaItem.image ?? mediaItem.placeholderImage
+        case .attachment(let text, let item):
+            pasteBoard.items = [
+                [kUTTypeUTF8PlainText as String : text]
+            ]
+
+            if let imageData = (item.image ?? item.placeholderImage).pngData() {
+                pasteBoard.addItems([
+                    [kUTTypePNG as String: imageData]
+                ])
+            }
         default:
             break
         }

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -300,6 +300,10 @@ UICollectionViewDelegateFlowLayout, UICollectionViewDataSource {
             let cell = messagesCollectionView.dequeueReusableCell(SystemMessageCell.self, for: indexPath)
             cell.configure(with: message, at: indexPath, and: messagesCollectionView)
             return cell
+        case .attachment:
+            let cell = messagesCollectionView.dequeueReusableCell(AttachmentMessageCell.self, for: indexPath)
+            cell.configure(with: message, at: indexPath, and: messagesCollectionView)
+            return cell
         }
     }
 

--- a/Sources/Extensions/CGRect+Extensions.swift
+++ b/Sources/Extensions/CGRect+Extensions.swift
@@ -31,3 +31,24 @@ internal extension CGRect {
     }
 
 }
+
+internal extension CGSize {
+
+    func aspectFit(minWidth: CGFloat, maxWidth: CGFloat) -> CGSize {
+        if self.width > maxWidth {
+            let height = maxWidth * self.aspectRatio
+            return CGSize(width: maxWidth, height: height)
+        }
+
+        if self.width < minWidth {
+            let height = minWidth * self.aspectRatio
+            return CGSize(width: minWidth, height: height)
+        }
+
+        return self
+    }
+
+    var aspectRatio: CGFloat {
+        return self.height / self.width
+    }
+}

--- a/Sources/Extensions/UIImage+Extension.swift
+++ b/Sources/Extensions/UIImage+Extension.swift
@@ -39,5 +39,32 @@ public extension UIImage {
         let image = UIImage(contentsOfFile: imagePath ?? "")
         return image
     }
-    
+
+    class func resize(image: UIImage, targetSize: CGSize) -> UIImage {
+        let size = image.size
+        let widthRatio  = targetSize.width  / image.size.width
+        let heightRatio = targetSize.height / image.size.height
+
+        var newSize: CGSize
+        if widthRatio > heightRatio {
+            newSize = CGSize(width: size.width * heightRatio, height: size.height * heightRatio)
+        } else {
+            newSize = CGSize(width: size.width * widthRatio,  height: size.height * widthRatio)
+        }
+
+        let rect = CGRect(x: 0, y: 0, width: newSize.width, height: newSize.height)
+
+        UIGraphicsBeginImageContextWithOptions(newSize, false, 0)
+        image.draw(in: rect)
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        return newImage!
+    }
+
+    func scale(by scale: CGFloat) -> UIImage {
+        let size = self.size
+        let scaledSize = CGSize(width: size.width * scale, height: size.height * scale)
+        return UIImage.resize(image: self, targetSize: scaledSize)
+    }
 }

--- a/Sources/Layout/AttachmentMessageSizeCalculator.swift
+++ b/Sources/Layout/AttachmentMessageSizeCalculator.swift
@@ -62,7 +62,6 @@ open class AttachmentMessageSizeCalculator: MessageSizeCalculator {
         let height = labelSize.height + imageSize.height
 
         let size = CGSize(width: width, height: height)
-        print("size: \(size)")
         return size
     }
 

--- a/Sources/Layout/AttachmentMessageSizeCalculator.swift
+++ b/Sources/Layout/AttachmentMessageSizeCalculator.swift
@@ -1,0 +1,87 @@
+/*
+ MIT License
+
+ Copyright (c) 2017-2019 MessageKit
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+import Foundation
+
+open class AttachmentMessageSizeCalculator: MessageSizeCalculator {
+
+    public var incomingMessageLabelInsets = UIEdgeInsets(top: 7, left: 18, bottom: 9, right: 14)
+    public var outgoingMessageLabelInsets = UIEdgeInsets(top: 7, left: 14, bottom: 9, right: 18)
+
+    public var messageLabelFont = UIFont.preferredFont(forTextStyle: .body)
+
+    internal func messageLabelInsets(for message: MessageType) -> UIEdgeInsets {
+        let dataSource = messagesLayout.messagesDataSource
+        let isFromCurrentSender = dataSource.isFromCurrentSender(message: message)
+        return isFromCurrentSender ? outgoingMessageLabelInsets : incomingMessageLabelInsets
+    }
+
+    open override func messageContainerMaxWidth(for message: MessageType) -> CGFloat {
+        let maxWidth = super.messageContainerMaxWidth(for: message)
+        let textInsets = messageLabelInsets(for: message)
+        return maxWidth - textInsets.horizontal
+    }
+
+    open override func messageContainerSize(for message: MessageType) -> CGSize {
+        let maxWidth = messageContainerMaxWidth(for: message)
+        let attributedText: NSAttributedString
+
+        guard case .attachment(let text, let item) = message.kind else {
+            fatalError("messageContainerSize received unhandled MessageDataType: \(message.kind)")
+        }
+        attributedText = NSAttributedString(string: text, attributes: [.font: messageLabelFont])
+
+        let labelInsets = self.messageLabelInsets(for: message)
+        let imageSize = item.placeholderImage.size.aspectFit(minWidth: 250, maxWidth: maxWidth)
+        var labelSize = self.labelSize(for: attributedText, considering: imageSize.width - labelInsets.horizontal)
+
+        labelSize.height += labelInsets.vertical
+
+        let width = imageSize.width
+        let height = labelSize.height + imageSize.height
+
+        let size = CGSize(width: width, height: height)
+        print("size: \(size)")
+        return size
+    }
+
+    open override func configure(attributes: UICollectionViewLayoutAttributes) {
+        super.configure(attributes: attributes)
+        guard let attributes = attributes as? MessagesCollectionViewLayoutAttributes else { return }
+
+        let dataSource = messagesLayout.messagesDataSource
+        let indexPath = attributes.indexPath
+        let message = dataSource.messageForItem(at: indexPath, in: messagesLayout.messagesCollectionView)
+
+        attributes.messageLabelInsets = messageLabelInsets(for: message)
+        attributes.messageLabelFont = messageLabelFont
+    }
+
+    override func labelSize(for attributedText: NSAttributedString, considering maxWidth: CGFloat) -> CGSize {
+        let label = MessageLabel()
+        label.attributedText = attributedText
+        let size = label.sizeThatFits(CGSize(width: maxWidth, height: .greatestFiniteMagnitude))
+        return size
+    }
+}

--- a/Sources/Layout/AttachmentMessageSizeCalculator.swift
+++ b/Sources/Layout/AttachmentMessageSizeCalculator.swift
@@ -53,7 +53,8 @@ open class AttachmentMessageSizeCalculator: MessageSizeCalculator {
         attributedText = NSAttributedString(string: text, attributes: [.font: messageLabelFont])
 
         let labelInsets = self.messageLabelInsets(for: message)
-        let imageSize = item.placeholderImage.size.aspectFit(minWidth: 250, maxWidth: maxWidth)
+        let image = item.image ?? item.placeholderImage
+        let imageSize = image.size.aspectFit(minWidth: 250, maxWidth: maxWidth)
         var labelSize = self.labelSize(for: attributedText, considering: imageSize.width - labelInsets.horizontal)
 
         labelSize.height += labelInsets.vertical

--- a/Sources/Layout/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/Layout/MessagesCollectionViewFlowLayout.swift
@@ -170,6 +170,7 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
     lazy open var contactMessageSizeCalculator = ContactMessageSizeCalculator(layout: self)
     lazy open var typingIndicatorSizeCalculator = TypingCellSizeCalculator(layout: self)
     lazy open var systemMessageSizeCalculator = SystemMessageSizeCalculator(layout: self)
+    lazy open var attachmentMessageSizeCalculator = AttachmentMessageSizeCalculator(layout: self)
 
     /// Note:
     /// - If you override this method, remember to call MessageLayoutDelegate's
@@ -203,6 +204,8 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
             return messagesLayoutDelegate.customCellSizeCalculator(for: message, at: indexPath, in: messagesCollectionView)
         case .system:
             return systemMessageSizeCalculator
+        case .attachment:
+            return attachmentMessageSizeCalculator
         }
     }
     // swiftlint:enable cyclomatic_complexity
@@ -326,7 +329,9 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
                 videoMessageSizeCalculator,
                 locationMessageSizeCalculator,
                 audioMessageSizeCalculator,
-                contactMessageSizeCalculator
+                contactMessageSizeCalculator,
+                systemMessageSizeCalculator,
+                attachmentMessageSizeCalculator
         ]
     }
     

--- a/Sources/Models/MessageKind.swift
+++ b/Sources/Models/MessageKind.swift
@@ -66,6 +66,9 @@ public enum MessageKind {
     /// A system message.
     case system(NSAttributedString)
 
+    /// A photo and text message
+    case attachment(String, MediaItem)
+
     // MARK: - Not supported yet
 
 //    case placeholder

--- a/Sources/Protocols/MessageCellDelegate.swift
+++ b/Sources/Protocols/MessageCellDelegate.swift
@@ -149,6 +149,16 @@ public protocol MessageCellDelegate: MessageLabelDelegate {
     /// method `messageForItem(at:indexPath:messagesCollectionView)`.
     func didStopAudio(in cell: AudioMessageCell)
 
+
+    /// Triggered when imageView of AttachmentMessageCell is tapped on
+    ///
+    /// - Parameters:
+    ///   - cell: The cell where the imageView was tapped on.
+    ///
+    /// You can get a reference to the `MessageType` for the cell by using `UICollectionView`'s
+    /// `indexPath(for: cell)` method. Then using the returned `IndexPath` with the `MessagesDataSource`
+    /// method `messageForItem(at:indexPath:messagesCollectionView)`.
+    func didTapAttachment(in cell: AttachmentMessageCell)
 }
 
 public extension MessageCellDelegate {

--- a/Sources/Views/Cells/AttachmentMessageCell.swift
+++ b/Sources/Views/Cells/AttachmentMessageCell.swift
@@ -101,10 +101,7 @@ open class AttachmentMessageCell: MessageContentCell {
     open override func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
         super.configure(with: message, at: indexPath, and: messagesCollectionView)
 
-        guard let displayDelegate = messagesCollectionView.messagesDisplayDelegate else {
-            fatalError(MessageKitError.nilMessagesDisplayDelegate)
-        }
-
+        guard let displayDelegate = messagesCollectionView.messagesDisplayDelegate else { fatalError(MessageKitError.nilMessagesDisplayDelegate) }
         guard case .attachment(let text, let item) = message.kind else { return }
 
         let enabledDetectors = displayDelegate.enabledDetectors(for: message, at: indexPath, in: messagesCollectionView)

--- a/Sources/Views/Cells/AttachmentMessageCell.swift
+++ b/Sources/Views/Cells/AttachmentMessageCell.swift
@@ -129,6 +129,20 @@ open class AttachmentMessageCell: MessageContentCell {
         let aspectRatioConstraint = self.imageView.heightAnchor.constraint(equalTo: self.imageView.widthAnchor, multiplier: multiplier, constant: 0)
         aspectRatioConstraint.isActive = true
         self.aspectRatioConstraint = aspectRatioConstraint
+
+        displayDelegate.configureMediaMessageImageView(self.imageView, for: message, at: indexPath, in: messagesCollectionView)
+    }
+
+    /// Handle tap gesture on contentView and its subviews.
+    open override func handleTapGesture(_ gesture: UIGestureRecognizer) {
+        let touchLocation = gesture.location(in: self)
+
+        if imageView.frame.contains(self.convert(touchLocation, to: imageView)) {
+            delegate?.didTapAttachment(in: self)
+            return
+        }
+
+        super.handleTapGesture(gesture)
     }
 
     /// Used to handle the cell's contentView's tap gesture.

--- a/Sources/Views/Cells/AttachmentMessageCell.swift
+++ b/Sources/Views/Cells/AttachmentMessageCell.swift
@@ -1,0 +1,150 @@
+/*
+ MIT License
+
+ Copyright (c) 2017-2019 MessageKit
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+import UIKit
+
+/// A subclass of `MessageContentCell` used to display attachment messages.
+open class AttachmentMessageCell: MessageContentCell {
+
+    private var aspectRatioConstraint: NSLayoutConstraint?
+
+    // MARK: - Properties
+
+    /// The `MessageCellDelegate` for the cell.
+    open override weak var delegate: MessageCellDelegate? {
+        didSet {
+            messageLabel.delegate = delegate
+        }
+    }
+
+    /// The label used to display the message's text.
+    open var messageLabel: MessageLabel = {
+        let label = MessageLabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    /// The image view display the media content.
+    open var imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFill
+        imageView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        return imageView
+    }()
+
+    // MARK: - Methods
+
+    /// Responsible for setting up the constraints of the cell's subviews.
+    open func setupConstraints() {
+        NSLayoutConstraint.activate([
+            self.imageView.leadingAnchor.constraint(equalTo: self.messageContainerView.leadingAnchor),
+            self.imageView.trailingAnchor.constraint(equalTo: self.messageContainerView.trailingAnchor),
+            self.imageView.topAnchor.constraint(equalTo: self.messageContainerView.topAnchor),
+            self.imageView.widthAnchor.constraint(greaterThanOrEqualToConstant: 250),
+
+            self.messageLabel.leadingAnchor.constraint(equalTo: self.messageContainerView.leadingAnchor),
+            self.messageLabel.trailingAnchor.constraint(equalTo: self.messageContainerView.trailingAnchor),
+            self.messageLabel.bottomAnchor.constraint(equalTo: self.messageContainerView.bottomAnchor),
+            self.messageLabel.topAnchor.constraint(equalTo: self.imageView.bottomAnchor)
+        ])
+    }
+
+    open override func setupSubviews() {
+        super.setupSubviews()
+        self.messageContainerView.addSubview(self.imageView)
+        self.messageContainerView.addSubview(self.messageLabel)
+        self.setupConstraints()
+    }
+
+    open override func prepareForReuse() {
+        super.prepareForReuse()
+        self.imageView.image = nil
+        self.messageLabel.attributedText = nil
+        self.messageLabel.text = nil
+
+        guard let aspectRatioConstraint = self.aspectRatioConstraint else { return }
+
+        self.imageView.removeConstraint(aspectRatioConstraint)
+        self.aspectRatioConstraint = nil
+    }
+
+    open override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
+        super.apply(layoutAttributes)
+        guard let attributes = layoutAttributes as? MessagesCollectionViewLayoutAttributes else { return }
+
+        messageLabel.textInsets = attributes.messageLabelInsets
+        messageLabel.messageLabelFont = attributes.messageLabelFont
+    }
+
+    open override func configure(with message: MessageType, at indexPath: IndexPath, and messagesCollectionView: MessagesCollectionView) {
+        super.configure(with: message, at: indexPath, and: messagesCollectionView)
+
+        guard let displayDelegate = messagesCollectionView.messagesDisplayDelegate else {
+            fatalError(MessageKitError.nilMessagesDisplayDelegate)
+        }
+
+        guard case .attachment(let text, let item) = message.kind else { return }
+
+        let enabledDetectors = displayDelegate.enabledDetectors(for: message, at: indexPath, in: messagesCollectionView)
+        self.messageLabel.configure {
+            self.messageLabel.enabledDetectors = enabledDetectors
+            for detector in enabledDetectors {
+                let attributes = displayDelegate.detectorAttributes(for: detector, and: message, at: indexPath)
+                self.messageLabel.setAttributes(attributes, detector: detector)
+            }
+
+            let textColor = displayDelegate.textColor(for: message, at: indexPath, in: messagesCollectionView)
+            self.messageLabel.text = text
+            self.messageLabel.textColor = textColor
+            if let font = messageLabel.messageLabelFont {
+                self.messageLabel.font = font
+            }
+        }
+
+        let image = item.image ?? item.placeholderImage
+        self.imageView.image = image
+        let multiplier = image.size.aspectRatio
+        let aspectRatioConstraint = self.imageView.heightAnchor.constraint(equalTo: self.imageView.widthAnchor, multiplier: multiplier, constant: 0)
+        aspectRatioConstraint.isActive = true
+        self.aspectRatioConstraint = aspectRatioConstraint
+    }
+
+    /// Used to handle the cell's contentView's tap gesture.
+    /// Return false when the contentView does not need to handle the gesture.
+    open override func cellContentView(canHandle touchPoint: CGPoint) -> Bool {
+        let convertedPoint = self.messageContainerView.convert(touchPoint, to: self.messageLabel)
+        return self.messageLabel.handleGesture(convertedPoint)
+    }
+}
+
+private extension AttachmentMessageCell {
+
+    func labelSize(for attributedText: NSAttributedString, considering maxWidth: CGFloat) -> CGSize {
+        let constraintBox = CGSize(width: maxWidth, height: .greatestFiniteMagnitude)
+        let rect = attributedText.boundingRect(with: constraintBox, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil).integral
+
+        return CGSize(width: rect.width, height: rect.height + messageLabel.textInsets.horizontal)
+    }
+}

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -451,8 +451,7 @@ open class MessageLabel: UILabel {
 
     }
 
-  open func handleGesture(_ touchLocation: CGPoint) -> Bool {
-
+    open func handleGesture(_ touchLocation: CGPoint) -> Bool {
         guard let index = stringIndex(at: touchLocation) else { return false }
 
         for (detectorType, ranges) in rangesForDetectors {

--- a/Sources/Views/MessagesCollectionView.swift
+++ b/Sources/Views/MessagesCollectionView.swift
@@ -80,6 +80,7 @@ open class MessagesCollectionView: UICollectionView {
         register(ContactMessageCell.self)
         register(TypingIndicatorCell.self)
         register(SystemMessageCell.self)
+        register(AttachmentMessageCell.self)
         register(MessageReusableView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader)
         register(MessageReusableView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter)
     }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Add MessageCell for attachment & text

Does this close any currently open issues?
------------------------------------------
No

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone 11 Pro, iPad Air (3rd Generation)

**iOS Version:** iOS 13.3

**Swift Version:** Swift 5

**MessageKit Version:** 3.0